### PR TITLE
Stop repeated keypresses from causing lag

### DIFF
--- a/scrollIt.js
+++ b/scrollIt.js
@@ -71,6 +71,9 @@
          */
         var keyNavigation = function (e) {
             var key = e.which;
+            if($('html,body').is(':animated') && (key == settings.upKey || key == settings.downKey)) {
+                return false;
+            }
             if(key == settings.upKey && active > 0) {
                 navigate(parseInt(active) - 1);
                 return false;


### PR DESCRIPTION
Currently, holding the up key or down key causes scrolling to lag as animate() is called repeatedly in rapid succession. This commit fixes this problem by ignoring up/down keypresses while scrolling is already happening.
