### PR TITLE
Modified topOffset option and added $.scrollIt.destroy() function to remove event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $.scrollIt({
   scrollTime: 600,       // how long (in ms) the animation takes
   activeClass: 'active', // class given to the active nav element
   onPageChange: null,    // function(pageIndex) that is called when page is changed
-  topOffset: 0           // offste (in px) for fixed top navigation
+  topOffset: { val: 0 }           // offste (in px) for fixed top navigation
 });
 ```
 

--- a/scrollIt.js
+++ b/scrollIt.js
@@ -22,7 +22,7 @@
         scrollTime: 600,
         activeClass: 'active',
         onPageChange: null,
-        topOffset : 0
+        topOffset : { val: 0}
     };
 
     $.scrollIt = function(options) {
@@ -46,7 +46,7 @@
         var navigate = function(ndx) {
             if(ndx < 0 || ndx > lastIndex) return;
 
-            var targetTop = $('[data-scroll-index=' + ndx + ']').offset().top + settings.topOffset + 1;
+            var targetTop = $('[data-scroll-index=' + ndx + ']').offset().top + settings.topOffset.val + 1;
             $('html,body').animate({
                 scrollTop: targetTop,
                 easing: settings.easing
@@ -61,7 +61,7 @@
         var doScroll = function (e) {
             var target = $(e.target).closest("[data-scroll-nav]").attr('data-scroll-nav') ||
             $(e.target).closest("[data-scroll-goto]").attr('data-scroll-goto');
-            navigate(parseInt(target));
+            navigate(parseInt(target, 10));
         };
 
         /**
@@ -75,10 +75,10 @@
                 return false;
             }
             if(key == settings.upKey && active > 0) {
-                navigate(parseInt(active) - 1);
+                navigate(parseInt(active, 10) - 1);
                 return false;
             } else if(key == settings.downKey && active < lastIndex) {
-                navigate(parseInt(active) + 1);
+                navigate(parseInt(active, 10) + 1);
                 return false;
             }
             return true;
@@ -106,8 +106,8 @@
             var winTop = $(window).scrollTop();
 
             var visible = $('[data-scroll-index]').filter(function(ndx, div) {
-                return winTop >= $(div).offset().top + settings.topOffset &&
-                winTop < $(div).offset().top + (settings.topOffset) + $(div).outerHeight()
+                return winTop >= $(div).offset().top + settings.topOffset.val &&
+                winTop < $(div).offset().top + (settings.topOffset.val) + $(div).outerHeight();
             });
             var newActive = visible.first().attr('data-scroll-index');
             updateActive(newActive);

--- a/scrollIt.js
+++ b/scrollIt.js
@@ -25,6 +25,13 @@
         topOffset : { val: 0}
     };
 
+    var listeners = {
+        scroll : null,
+        keydown: null,
+        click: null,
+    };
+
+
     $.scrollIt = function(options) {
 
         /*
@@ -120,10 +127,24 @@
 
         $(window).on('keydown', keyNavigation);
 
-        $('body').on('click','[data-scroll-nav], [data-scroll-goto]', function(e){
+        var clickHandler = function(e){
             e.preventDefault();
             doScroll(e);
-        });
+        };
 
+        $('body').on('click','[data-scroll-nav], [data-scroll-goto]', clickHandler);
+
+        listeners.scroll = watchActive;
+        listeners.keydown = keyNavigation;
+        listeners.click = clickHandler;
     };
+
+    $.scrollIt.listeners = listeners;
+
+    $.scrollIt.destroy = function () {
+        $(window).off('scroll', listeners.scroll);
+        $(window).off('keydown', listeners.keydown);
+        $('body').off('click','[data-scroll-nav], [data-scroll-goto]', listeners.click);
+    };
+
 }(jQuery));


### PR DESCRIPTION
Breaking Change:
Modified the topOffset option to accept an object with { val : 0 }. The way Javascript works, this enables us to keep a variable outside of scrollIt like this:

``` javascript
var topOffset = {
  val: -30
}

$.scrollIt({
  topOffset : topOffset
});

topOffset.val = -90; // scrollIt will now use updated topOffset
```

This modification is pretty useful, when you want to create responsive layouts in combination with scrollIt.

Second change: I added a function to remove the scrollIt event handlers. This is quite useful when building a single page app or using frameworks like Ember, so that you can cleanly remove scrollIt and re-initialize it when you move around the page.

Use `$.scrollIt.destroy()`

Cheers!
