### PR TITLE
data-index(indexLast) miss parseint

### DIFF
--- a/scrollIt.js
+++ b/scrollIt.js
@@ -32,7 +32,7 @@
          */
         var settings = $.extend(defaults, options),
             active = 0,
-            lastIndex = $('[data-scroll-index]:last').attr('data-scroll-index');
+            lastIndex = parseInt($('[data-scroll-index]:last').attr('data-scroll-index'));
 
         /*
          * METHODS


### PR DESCRIPTION
I found that sometimes the keydown/keyup scroll does not work properly because indexLast is being treated as a string, causing active > indexLast. If we make lastIndex = parseInt($('[data-scroll-index]:last').attr('data-scroll-index')); that solves the problem. 
